### PR TITLE
Add DROP confirmation when running locally

### DIFF
--- a/snowflake_manager/cli.py
+++ b/snowflake_manager/cli.py
@@ -1,6 +1,6 @@
 import argparse
 import logging
-import subprocess
+import sys
 
 from rich.console import Console
 from rich.logging import RichHandler
@@ -9,7 +9,6 @@ from snowflake_manager.core import drop_create_objects
 from snowflake_manager.utils import (
     run_command,
     log_dry_run_info,
-    log_error_due_to_missing_object_in_snowflake,
 )
 
 
@@ -25,10 +24,13 @@ def drop_create(args):
     console.log("[bold][purple]Drop/create Snowflake objects[/purple] started[/bold]")
     if args.dry:
         log_dry_run_info()
-    drop_create_objects(args.permifrost_spec_path, args.dry)
-    console.log(
-        "[bold][purple]\nDrop/create Snowflake objects[/purple] completed successfully[/bold]\n"
-    )
+    is_success = drop_create_objects(args.permifrost_spec_path, args.dry)
+    if is_success:
+        console.log(
+            "[bold][purple]\nDrop/create Snowflake objects[/purple] completed successfully[/bold]\n"
+        )
+    else:
+        sys.exit(1)
 
 
 def permifrost(args):
@@ -44,18 +46,9 @@ def permifrost(args):
         cmd.append("--dry")
         log_dry_run_info()
 
-    try:
-        console.log(f"Running command: \n[italic]{' '.join(cmd)}[/italic]\n")
-        run_command(cmd)
-        console.log("[bold][purple]Permifrost[/purple] completed successfully[bold]\n")
-    except subprocess.CalledProcessError as exc:
-        error_msg = exc.output
-        if "Object does not exist" in error_msg:
-            log_error_due_to_missing_object_in_snowflake(error_msg)
-            raise exc
-        else:
-            log.error(error_msg)
-            raise exc
+    console.log(f"Running command: \n[italic]{' '.join(cmd)}[/italic]\n")
+    run_command(cmd)
+    console.log("[bold][purple]Permifrost[/purple] completed successfully[bold]\n")
 
 
 def run(args):

--- a/snowflake_manager/core.py
+++ b/snowflake_manager/core.py
@@ -98,9 +98,11 @@ def execute_ddl(cursor, statements: List) -> None:
     """
     console.log("\n[bold]Executing DDL statements[/bold]:")
     for s in statements:
-        console.log(s)
         cursor.execute(s)
-        console.log("Executed successfully\n")
+        if s.startswith("USE ROLE"):
+            continue
+        console.log(f"[green]\u2713[/green] [italic]{s}[/italic]")
+        # console.log("\n")
 
 
 def resolve_objects(

--- a/snowflake_manager/core.py
+++ b/snowflake_manager/core.py
@@ -213,6 +213,12 @@ def drop_create_objects(permifrost_spec_path: str, is_dry_run: bool):
     ddl_statements_seq = build_statements_list(all_ddl_statements)
     print_ddl_statements(ddl_statements_seq)
     drop_statements = [s for s in ddl_statements_seq if s.startswith("DROP")]
+
+    if IS_CI_RUN:
+        console.log(
+            "[bold][yellow]CI run detected[/bold][/yellow]: Skipping DROP confirmation"
+        )
+
     if not is_dry_run and not IS_CI_RUN and drop_statements:
         console.log(
             f"\n[bold][red]WARNING[/bold][/red]: The following DROP statements are about to be executed: {(drop_statements)}"

--- a/snowflake_manager/core.py
+++ b/snowflake_manager/core.py
@@ -37,8 +37,8 @@ log = logging.getLogger(__name__)
 log.setLevel("INFO")
 console = Console()
 
-# GITHUB_ACTIONS is a default environment variable in GitHub Actions
-IS_CI_RUN = os.getenv("GITHUB_ACTIONS") == "true"
+# Compatible with GitHub, GitLab and Bitbucket
+IS_CI_RUN = os.getenv("CI") == "true"
 
 
 def build_statements_list(statements: Dict) -> List:

--- a/snowflake_manager/core.py
+++ b/snowflake_manager/core.py
@@ -1,8 +1,10 @@
 import logging
-from typing import FrozenSet, Dict
+import os
+from typing import FrozenSet, Dict, List
 
 from rich.console import Console
 from rich.logging import RichHandler
+from rich.prompt import Prompt
 from yaml import load, Loader
 
 from snowflake_manager.constants import DDL_ROLE, OBJECT_TYPES
@@ -35,25 +37,70 @@ log = logging.getLogger(__name__)
 log.setLevel("INFO")
 console = Console()
 
+# GITHUB_ACTIONS is a default environment variable in GitHub Actions
+IS_CI_RUN = os.getenv("GITHUB_ACTIONS") == "true"
 
-def execute_ddl(cursor, statements: dict, is_dry_run: bool) -> None:
+
+def build_statements_list(statements: Dict) -> List:
+    """
+    Build a list of statements to be executed from a dictionary of statements with the
+    structure:
+    {
+        "user": {
+            "drop": ["DROP USER ...", "DROP USER ..."],
+            "create": ["CREATE USER ..., "CREATE USER ..."],
+            "alter": ["ALTER USER ..., "ALTER USER ..."],
+        }
+    }
+
+    To a list of statements like:
+    ["DROP USER ...", "DROP USER ...", "CREATE USER ..., "ALTER USER ..."]
+
+    Args:
+        statements: dict with the list of statements of each type (e.g. create, drop)
+                    it assumes statements come as pairs  like "USE ROLE...; CREATE/DROP ..."
+
+    Returns:
+        statements_seq: list with drop, create and alter statements in sequence for all
+                        object types
+    """
+    statements_seq = []
+    for object_type in OBJECT_TYPES:
+        for operation in ["drop", "create", "alter"]:  # Order matters
+            for statement_pair in statements[object_type][operation]:
+                for s in statement_pair.split(";"):
+                    if s:  # Ignore empty strings
+                        statements_seq.append(s)
+    return statements_seq
+
+
+def print_ddl_statements(statements: Dict) -> None:
+    """Print DDL statements to be executed."""
+    if not statements:
+        console.log(
+            "No statements to execute (the state of Snowflake objects matches the Permifrost spec)\n"
+        )
+        return
+    for s in statements:
+        if s.startswith("USE ROLE"):
+            continue
+        console.log(f"[italic]- {s}[/italic]")
+    console.log()
+
+
+def execute_ddl(cursor, statements: List) -> None:
     """Execute drop, create and alter statements in sequence for each object type.
 
     Args:
         cursor: Snowflake API cursor object
-        statements: dict with the list of statements of each type (e.g. create, drop)
-                    it assumes statements come as pairs  like "USE ROLE...; CREATE/DROP ..."
-        is_dry_run: when true, skips any create or drop statement (only prints it)
+        statements: list with drop, create and alter statements in sequence for all
+                    object types
     """
-    for object_type in OBJECT_TYPES:
-        for operation in ["drop", "create", "alter"]:
-            for statement_pair in statements[object_type][operation]:
-                for s in statement_pair.split(";"):
-                    if s:  # Ignore empty strings
-                        console.log(s)
-                        if not is_dry_run:
-                            cursor.execute(s)
-                            console.log("Executed successfully\n")
+    console.log("\n[bold]Executing DDL statements[/bold]:")
+    for s in statements:
+        console.log(s)
+        cursor.execute(s)
+        console.log("Executed successfully\n")
 
 
 def resolve_objects(
@@ -142,7 +189,16 @@ def resolve_objects(
 
 
 def drop_create_objects(permifrost_spec_path: str, is_dry_run: bool):
-    """Drop and create Snowflake objects based on Permifrost specification and inspection of Snowflake metadata."""
+    """
+    Drop and create Snowflake objects based on Permifrost specification and inspection of Snowflake metadata.
+
+    Args:
+        permifrost_spec_path: path to the Permifrost specification file
+        is_dry_run: flag to run the operation in dry-run mode
+
+    Returns:
+        bool: True if the operation was successful, False otherwise
+    """
     permifrost_spec = load(open(permifrost_spec_path, "r"), Loader=Loader)
 
     for object_type in OBJECT_TYPES:
@@ -151,17 +207,23 @@ def drop_create_objects(permifrost_spec_path: str, is_dry_run: bool):
             parse_object_type(permifrost_spec, object_type),
         )
 
-    console.log("\nDDL Statements:")
-    execute_ddl(get_snowflake_cursor(), all_ddl_statements, is_dry_run)
-
-    is_empty = True
-    for object_type in OBJECT_TYPES:
-        for operation in ["drop", "create", "alter"]:
-            if len(all_ddl_statements[object_type][operation]) > 0:
-                is_empty = False
-                break
-    if is_empty:
+    console.log("\n[bold]DDL statements to be executed[/bold]:")
+    ddl_statements_seq = build_statements_list(all_ddl_statements)
+    print_ddl_statements(ddl_statements_seq)
+    drop_statements = [s for s in ddl_statements_seq if s.startswith("DROP")]
+    if not is_dry_run and not IS_CI_RUN and drop_statements:
         console.log(
-            "No statements to execute (state of Snowflake objects matches Permifrost spec)\n"
+            f"\n[bold][red]WARNING[/bold][/red]: The following DROP statements are about to be executed: {(drop_statements)}"
         )
-    console.log()
+        user_input = Prompt.ask(
+            "\n\t>>> Type [bold]drop[/bold] to proceed or any other key to abort"
+        )
+        if user_input.lower() != "drop":
+            console.log()
+            console.log("Exited without executing any statements")
+            return False
+
+    if not is_dry_run:
+        execute_ddl(get_snowflake_cursor(), ddl_statements_seq)
+
+    return True

--- a/snowflake_manager/utils.py
+++ b/snowflake_manager/utils.py
@@ -90,23 +90,3 @@ def log_dry_run_info():
     console.log(20 * "-")
     console.log("[bold]Executing in [yellow]dry run mode[/yellow][/bold]")
     console.log(20 * "-")
-
-
-def log_error_due_to_missing_object_in_snowflake(error_msg: str):
-    first_line = f"Permifrost failed due to an object that does not exist in Snowflake yet. Full error message: {error_msg}"
-    match = re.search(r"SQL: SHOW TERSE TABLES IN DATABASE (\S+)]", error_msg)
-    if match:
-        database_name = match.group(1)
-        first_line = f"Permifrost failed due to a database that does not exist in Snowflake yet: `{database_name}`. "
-
-    log.error(
-        textwrap.dedent(
-            f"""
-        {first_line}
-        This is expected if the object was just added to Permifrost spec and a normal drop/create run was not performed yet.
-        ---
-        Note: this error is common when running in dry run mode in CI/CD checks after adding a new user and related databases to the Permifrost spec. In this case, it is recommended to ignore the error, review the DDL statements that would be run (in the logs above), double check the PR changes and proceed with merging the PR.
-        ---
-    """
-        ).strip()
-    )


### PR DESCRIPTION
## Description 

<!--- In this section, concisely describe what your Pull Request does, and why it is important (both in a technical and business value sense) -->
When setting it up with the first clients, we realized the local runs can be risky if the users are unaware it will drop objects.

## Changes

<!--- Please document here, if relevant, what has changed, and in which specific models -->
- Add prompt check if any drop statements are listed to be run
- Minor
    - Remove old and confusing error message when transient objects were found

## Checklist

<!--- Please make sure all of the below are checked off before submitting your PR ;) -->

- [x] My pull request represents one logical piece of work
- [x] My commits are related to the pull request and look clean
- [x] I tested my changes locally

## Preview
![image](https://github.com/user-attachments/assets/c598e3c7-d261-4ac2-a1bf-d8484e020cdb)
